### PR TITLE
Add GitHub Actions CI/CD pipeline for GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,55 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+        env:
+          VITE_BASE_URL: /GDS-Demo-App/
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: process.env.VITE_BASE_URL || '/',
   optimizeDeps: {
     exclude: ['lucide-react'],
   },


### PR DESCRIPTION
Adds automated deployment to GitHub Pages on every push to main. Includes Vite base URL configuration for the /GDS-Demo-App/ subpath.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set up CI/CD to build and deploy the Vite app to GitHub Pages on every push to `main`. Configured Vite `base` via `VITE_BASE_URL` to support the `/GDS-Demo-App/` subpath.

- **New Features**
  - Added `.github/workflows/deploy.yml` to build with Node 20 (`npm ci`, `npm run build`) and deploy to Pages.
  - Publishes `dist` with `actions/upload-pages-artifact@v3` and deploys via `actions/deploy-pages@v4`.
  - Triggers on `push` to `main` and `workflow_dispatch`, with Pages-safe concurrency.
  - `vite.config.ts`: `base: process.env.VITE_BASE_URL || '/'`; CI sets it to `/GDS-Demo-App/`.

<sup>Written for commit 8f9e0a9363154db4d98bc6ff2367f20aa0d6ef24. Summary will update on new commits. <a href="https://cubic.dev/pr/lokeshsharma99/GDS-Demo-App/pull/6?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

