### PR TITLE
feat: landing page service selector — choose benefit then Start now

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import GovUKHeader from './GovUKHeader';
 import GovUKFooter from './GovUKFooter';
 
@@ -6,7 +6,42 @@ interface LandingPageProps {
   onSelectService: (service: string) => void;
 }
 
+const SERVICES = [
+  {
+    id: 'universal-credit',
+    label: 'Universal Credit',
+    description: 'Monthly payment for people on low income or out of work. Replaces 6 legacy benefits.',
+  },
+  {
+    id: 'housing-benefit',
+    label: 'Housing Benefit',
+    description: 'Help with rent costs if you are on a low income or claiming other benefits.',
+  },
+  {
+    id: 'jobseekers-allowance',
+    label: "Jobseeker's Allowance",
+    description: 'Financial support while you are looking for work.',
+  },
+];
+
 const LandingPage: React.FC<LandingPageProps> = ({ onSelectService }) => {
+  const [selected, setSelected] = useState<string>('');
+  const [validationError, setValidationError] = useState(false);
+
+  const handleStart = () => {
+    if (!selected) {
+      setValidationError(true);
+      document.getElementById('service-error')?.focus();
+      return;
+    }
+    onSelectService(selected);
+  };
+
+  const handleChange = (value: string) => {
+    setSelected(value);
+    setValidationError(false);
+  };
+
   return (
     <>
       <a href="#main-content" className="govuk-skip-link">
@@ -38,24 +73,14 @@ const LandingPage: React.FC<LandingPageProps> = ({ onSelectService }) => {
             }}
           >
             <li>
-              <a href="https://www.gov.uk" style={{ color: '#1d70b8' }}>
-                Home
-              </a>
-              <span aria-hidden="true" style={{ marginLeft: '5px', color: '#505a5f' }}>
-                &rsaquo;
-              </span>
+              <a href="https://www.gov.uk" style={{ color: '#1d70b8' }}>Home</a>
+              <span aria-hidden="true" style={{ marginLeft: '5px', color: '#505a5f' }}>&rsaquo;</span>
             </li>
             <li>
-              <a href="#" style={{ color: '#1d70b8' }}>
-                Benefits
-              </a>
-              <span aria-hidden="true" style={{ marginLeft: '5px', color: '#505a5f' }}>
-                &rsaquo;
-              </span>
+              <a href="#" style={{ color: '#1d70b8' }}>Benefits</a>
+              <span aria-hidden="true" style={{ marginLeft: '5px', color: '#505a5f' }}>&rsaquo;</span>
             </li>
-            <li aria-current="page" style={{ color: '#0b0c0c' }}>
-              Universal Credit
-            </li>
+            <li aria-current="page" style={{ color: '#0b0c0c' }}>Apply for support</li>
           </ol>
         </nav>
 
@@ -66,56 +91,114 @@ const LandingPage: React.FC<LandingPageProps> = ({ onSelectService }) => {
             lineHeight: 1.1,
             color: '#0b0c0c',
             marginBottom: '20px',
-            borderBottom: 'none',
           }}
         >
-          Apply for Universal Credit
+          Apply for Benefits and Support
         </h1>
 
-        {/* Inset text */}
+        <p style={{ fontSize: '19px', color: '#0b0c0c', marginBottom: '30px' }}>
+          Select the benefit you want to apply for, then click <strong>Start now</strong> to begin your application.
+        </p>
+
+        {/* Service selection */}
         <div
-          style={{
-            borderLeft: '10px solid #b1b4b6',
-            paddingLeft: '15px',
-            marginBottom: '30px',
-          }}
+          role="group"
+          aria-labelledby="service-group-legend"
+          style={{ marginBottom: '30px' }}
         >
-          <p style={{ fontSize: '19px', margin: 0, color: '#0b0c0c' }}>
-            Universal Credit is a payment to help with your living costs. It's paid monthly —
-            or twice a month for some people in Scotland.
-          </p>
+          <fieldset style={{ border: 'none', padding: 0, margin: 0 }}>
+            <legend
+              id="service-group-legend"
+              style={{
+                fontSize: '24px',
+                fontWeight: 700,
+                color: '#0b0c0c',
+                marginBottom: '15px',
+                display: 'block',
+              }}
+            >
+              Which benefit are you applying for?
+            </legend>
+
+            {/* Validation error */}
+            {validationError && (
+              <p
+                id="service-error"
+                role="alert"
+                tabIndex={-1}
+                style={{
+                  color: '#d4351c',
+                  fontWeight: 700,
+                  fontSize: '19px',
+                  borderLeft: '4px solid #d4351c',
+                  paddingLeft: '15px',
+                  marginBottom: '15px',
+                }}
+              >
+                Select a benefit before continuing
+              </p>
+            )}
+
+            {/* Radio cards */}
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+              {SERVICES.map((svc) => {
+                const isChecked = selected === svc.id;
+                return (
+                  <label
+                    key={svc.id}
+                    htmlFor={`service-${svc.id}`}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'flex-start',
+                      gap: '15px',
+                      padding: '20px',
+                      border: isChecked ? '3px solid #0b0c0c' : '2px solid #b1b4b6',
+                      backgroundColor: isChecked ? '#f3f2f1' : '#ffffff',
+                      cursor: 'pointer',
+                      borderRadius: '0',
+                    }}
+                  >
+                    <input
+                      type="radio"
+                      id={`service-${svc.id}`}
+                      name="service"
+                      value={svc.id}
+                      checked={isChecked}
+                      onChange={() => handleChange(svc.id)}
+                      style={{
+                        width: '24px',
+                        height: '24px',
+                        flexShrink: 0,
+                        marginTop: '2px',
+                        cursor: 'pointer',
+                        accentColor: '#0b0c0c',
+                      }}
+                    />
+                    <div>
+                      <span
+                        style={{
+                          display: 'block',
+                          fontSize: '19px',
+                          fontWeight: 700,
+                          color: '#0b0c0c',
+                          marginBottom: '4px',
+                        }}
+                      >
+                        {svc.label}
+                      </span>
+                      <span style={{ fontSize: '17px', color: '#505a5f' }}>
+                        {svc.description}
+                      </span>
+                    </div>
+                  </label>
+                );
+              })}
+            </div>
+          </fieldset>
         </div>
 
-        {/* Warning text */}
-        <div
-          role="note"
-          aria-label="Important"
-          style={{
-            display: 'flex',
-            alignItems: 'flex-start',
-            gap: '10px',
-            marginBottom: '30px',
-          }}
-        >
-          <span
-            aria-hidden="true"
-            style={{
-              fontSize: '35px',
-              lineHeight: 1,
-              fontWeight: 700,
-              color: '#0b0c0c',
-              flexShrink: 0,
-            }}
-          >
-            !
-          </span>
-          <p style={{ margin: 0, fontWeight: 700, fontSize: '19px', color: '#0b0c0c' }}>
-            You might be able to apply if you're on a low income, out of work or you cannot work.
-          </p>
-        </div>
-
-        {/* Before you start panel */}
-        <section aria-labelledby="before-you-start">
+        {/* Before you start */}
+        <section aria-labelledby="before-you-start" style={{ marginBottom: '30px' }}>
           <h2
             id="before-you-start"
             style={{
@@ -129,57 +212,49 @@ const LandingPage: React.FC<LandingPageProps> = ({ onSelectService }) => {
           >
             Before you start
           </h2>
-
-          <p style={{ fontSize: '19px', color: '#0b0c0c', marginBottom: '15px' }}>
-            You'll need:
-          </p>
-
+          <p style={{ fontSize: '19px', color: '#0b0c0c', marginBottom: '15px' }}>You'll need:</p>
           <ul
             style={{
               fontSize: '19px',
               color: '#0b0c0c',
               paddingLeft: '20px',
-              marginBottom: '30px',
+              marginBottom: '20px',
               lineHeight: 1.6,
             }}
           >
             <li>your National Insurance number</li>
             <li>your bank, building society or credit union account details</li>
-            <li>information about your housing, for example how much rent you pay</li>
+            <li>information about your housing costs</li>
             <li>details of your income, for example payslips</li>
-            <li>details of savings and any investments, like shares or a property that you rent out</li>
-            <li>details of any other benefits you're getting</li>
+            <li>details of savings and any investments</li>
           </ul>
-
-          <p style={{ fontSize: '19px', color: '#0b0c0c', marginBottom: '30px' }}>
+          <p style={{ fontSize: '19px', color: '#0b0c0c' }}>
             This service takes around 30 to 45 minutes to complete.
           </p>
         </section>
 
-        {/* GDS Start button */}
+        {/* Start now button */}
         <button
-          onClick={() => onSelectService('universal-credit')}
+          onClick={handleStart}
           style={{
             display: 'inline-flex',
             alignItems: 'center',
             gap: '10px',
-            backgroundColor: '#00703c',
+            backgroundColor: selected ? '#00703c' : '#6f777b',
             color: '#ffffff',
             fontWeight: 700,
             fontSize: '24px',
             fontFamily: '"GDS Transport", arial, sans-serif',
             border: 'none',
             padding: '13px 20px',
-            cursor: 'pointer',
-            textDecoration: 'none',
-            position: 'relative',
-            boxShadow: '0 2px 0 #002d18',
+            cursor: selected ? 'pointer' : 'not-allowed',
+            boxShadow: selected ? '0 2px 0 #002d18' : '0 2px 0 #383f43',
             marginBottom: '30px',
           }}
-          aria-label="Start now – Apply for Universal Credit"
+          aria-disabled={!selected}
+          aria-describedby={validationError ? 'service-error' : undefined}
         >
           Start now
-          {/* Arrow */}
           <svg
             aria-hidden="true"
             focusable="false"
@@ -195,20 +270,11 @@ const LandingPage: React.FC<LandingPageProps> = ({ onSelectService }) => {
         {/* Help section */}
         <section
           aria-labelledby="get-help"
-          style={{
-            borderTop: '2px solid #1d70b8',
-            paddingTop: '20px',
-            marginTop: '20px',
-          }}
+          style={{ borderTop: '2px solid #1d70b8', paddingTop: '20px', marginTop: '20px' }}
         >
           <h2
             id="get-help"
-            style={{
-              fontSize: '24px',
-              fontWeight: 700,
-              color: '#0b0c0c',
-              marginBottom: '10px',
-            }}
+            style={{ fontSize: '24px', fontWeight: 700, color: '#0b0c0c', marginBottom: '10px' }}
           >
             Get help with your application
           </h2>

--- a/src/test/e2e/fr-01-landing-page.spec.ts
+++ b/src/test/e2e/fr-01-landing-page.spec.ts
@@ -26,6 +26,7 @@ test.describe('FR-01: Landing Page', () => {
   test('FR-01-04: Start Now button is present and navigates to Step 1', async ({ page }) => {
     const startBtn = page.getByRole('button', { name: /start now/i });
     await expect(startBtn).toBeVisible();
+    await page.getByRole('radio', { name: /universal credit/i }).check();
     await startBtn.click();
     await expect(page.getByText(/Personal details/i)).toBeVisible();
   });

--- a/src/test/e2e/fr-06-navigation.spec.ts
+++ b/src/test/e2e/fr-06-navigation.spec.ts
@@ -98,6 +98,7 @@ test.describe('FR-06: Navigation and Progress Indicator', () => {
     await expect(page.getByRole('button', { name: /start now/i })).toBeVisible();
 
     // Re-enter the form and check fields are empty
+    await page.getByRole('radio', { name: /universal credit/i }).check();
     await page.getByRole('button', { name: /start now/i }).click();
     await expect(page.getByLabel('First name')).toHaveValue('');
   });

--- a/src/test/e2e/fr-07-happy-path.spec.ts
+++ b/src/test/e2e/fr-07-happy-path.spec.ts
@@ -47,6 +47,7 @@ test.describe('FR-07: Full Happy Path — Complete Application Journey', () => {
     await expect(page.getByRole('contentinfo')).toBeVisible();
 
     // Step 1
+    await page.getByRole('radio', { name: /universal credit/i }).check();
     await page.getByRole('button', { name: /start now/i }).click();
     await expect(page.getByRole('banner')).toBeVisible();
     await expect(page.getByRole('contentinfo')).toBeVisible();

--- a/src/test/e2e/fr-08-keyboard-accessibility.spec.ts
+++ b/src/test/e2e/fr-08-keyboard-accessibility.spec.ts
@@ -48,6 +48,7 @@ test.describe('FR-08: Keyboard Accessibility', () => {
 
   test('FR-08-10: Start now button is activatable by keyboard', async ({ page }) => {
     await page.goto('/');
+    await page.getByRole('radio', { name: /universal credit/i }).check();
     const startBtn = page.getByRole('button', { name: /start now/i });
     await startBtn.focus();
     await expect(startBtn).toBeFocused();

--- a/src/test/e2e/helpers.ts
+++ b/src/test/e2e/helpers.ts
@@ -47,8 +47,9 @@ export async function fillStep3(page: import('@playwright/test').Page, data = VA
 }
 
 /** Navigate from landing page to Step 1 */
-export async function startApplication(page: import('@playwright/test').Page) {
+export async function startApplication(page: import('@playwright/test').Page, service = 'universal-credit') {
   await page.goto('/');
+  await page.getByRole('radio', { name: /universal credit/i }).check();
   await page.getByRole('button', { name: /start now/i }).click();
 }
 


### PR DESCRIPTION
## Summary
Replaces the old hardcoded 'Apply for Universal Credit' landing page with a proper service selection flow.

## Changes
- Added three radio-card options: **Universal Credit**, **Housing Benefit**, **Jobseeker's Allowance**
- Selecting a card highlights it with bold border and grey background
- **Start now** button is greyed out until a service is selected, then turns green
- Inline GDS-style validation error shown if user clicks Start without selecting
- E2E tests updated: all 69/69 passing locally

## Screenshots
| Before | After |
|--------|-------|
| Single 'Apply for Universal Credit' page with immediate Start now | Service selector with radio cards → Start now enables on selection |

## Test plan
- \
pm run test:e2e\ — 69 passed
- \
pm run test\ — 62 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the single-service landing page with a service selector so users choose a benefit before starting. Improves accessibility with disabled Start state and inline validation.

- **New Features**
  - Added radio-card options for Universal Credit, Housing Benefit, and Jobseeker’s Allowance.
  - Highlights the selected card; Start button enables only after a choice.
  - Updated breadcrumbs and heading; tightened “Before you start” copy.
  - Added ARIA roles and error focus for validation.
  - Updated e2e tests to select a service before starting; all tests pass.

<sup>Written for commit 49dfa5148ddd0b2a2e1498a1f4dddffa65ddb2f1. Summary will update on new commits. <a href="https://cubic.dev/pr/lokeshsharma99/GDS-Demo-App/pull/41?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

